### PR TITLE
fix: avoid requiring Rust 1.93 for raw string parts

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -59,13 +59,6 @@ pub const NON_LIT_LUT: [bool; 256] = {
 
 pub trait Sealed {}
 
-#[inline]
-pub(crate) fn string_into_raw_parts(value: std::string::String) -> (*mut u8, usize, usize) {
-    let mut value = core::mem::ManuallyDrop::new(value);
-
-    (value.as_mut_ptr(), value.len(), value.capacity())
-}
-
 #[inline(always)]
 pub fn likely(b: bool) -> bool {
     #[cfg(feature = "nightly")]

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -59,6 +59,13 @@ pub const NON_LIT_LUT: [bool; 256] = {
 
 pub trait Sealed {}
 
+#[inline]
+pub(crate) fn string_into_raw_parts(value: std::string::String) -> (*mut u8, usize, usize) {
+    let mut value = core::mem::ManuallyDrop::new(value);
+
+    (value.as_mut_ptr(), value.len(), value.capacity())
+}
+
 #[inline(always)]
 pub fn likely(b: bool) -> bool {
     #[cfg(feature = "nightly")]

--- a/src/serde/value.rs
+++ b/src/serde/value.rs
@@ -1,4 +1,7 @@
-use core::fmt::{self, Formatter};
+use core::{
+    fmt::{self, Formatter},
+    mem::ManuallyDrop,
+};
 
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
@@ -6,7 +9,6 @@ use serde::{
     ser::{SerializeMap, SerializeSeq},
 };
 
-use crate::misc::string_into_raw_parts;
 use crate::value::{
     Array, Number, Object, OwnedValue,
     borrowed::{String, Value},
@@ -305,7 +307,11 @@ impl<'de> Deserialize<'de> for String<'de> {
 
             #[inline]
             fn visit_string<E: Error>(self, v: std::string::String) -> Result<String<'de>, E> {
-                let (buf, len, cap) = string_into_raw_parts(v);
+                let mut v = ManuallyDrop::new(v);
+                let buf = v.as_mut_ptr();
+                let len = v.len();
+                let cap = v.capacity();
+
                 Ok(String::from_raw_parts(buf, len, cap))
             }
 

--- a/src/serde/value.rs
+++ b/src/serde/value.rs
@@ -308,11 +308,12 @@ impl<'de> Deserialize<'de> for String<'de> {
             #[inline]
             fn visit_string<E: Error>(self, v: std::string::String) -> Result<String<'de>, E> {
                 let mut v = ManuallyDrop::new(v);
-                let buf = v.as_mut_ptr();
-                let len = v.len();
-                let cap = v.capacity();
 
-                Ok(String::from_raw_parts(buf, len, cap))
+                Ok(String::from_raw_parts(
+                    v.as_mut_ptr(),
+                    v.len(),
+                    v.capacity(),
+                ))
             }
 
             #[inline]

--- a/src/serde/value.rs
+++ b/src/serde/value.rs
@@ -6,6 +6,7 @@ use serde::{
     ser::{SerializeMap, SerializeSeq},
 };
 
+use crate::misc::string_into_raw_parts;
 use crate::value::{
     Array, Number, Object, OwnedValue,
     borrowed::{String, Value},
@@ -304,7 +305,7 @@ impl<'de> Deserialize<'de> for String<'de> {
 
             #[inline]
             fn visit_string<E: Error>(self, v: std::string::String) -> Result<String<'de>, E> {
-                let (buf, len, cap) = v.into_raw_parts();
+                let (buf, len, cap) = string_into_raw_parts(v);
                 Ok(String::from_raw_parts(buf, len, cap))
             }
 

--- a/src/value/borrowed/string.rs
+++ b/src/value/borrowed/string.rs
@@ -173,11 +173,12 @@ impl From<std::string::String> for String<'_> {
     #[inline]
     fn from(value: std::string::String) -> Self {
         let mut value = ManuallyDrop::new(value);
-        let buf = value.as_mut_ptr();
-        let len = value.len();
-        let cap = value.capacity();
 
-        Self(Inner::Heap { buf, len, cap })
+        Self(Inner::Heap {
+            buf: value.as_mut_ptr(),
+            len: value.len(),
+            cap: value.capacity(),
+        })
     }
 }
 

--- a/src/value/borrowed/string.rs
+++ b/src/value/borrowed/string.rs
@@ -1,12 +1,12 @@
 use core::{
-    alloc::Layout, hint::unreachable_unchecked, ptr::dangling_mut, slice::from_raw_parts,
-    str::from_utf8_unchecked,
+    alloc::Layout, hint::unreachable_unchecked, mem::ManuallyDrop, ptr::dangling_mut,
+    slice::from_raw_parts, str::from_utf8_unchecked,
 };
 use std::alloc::{alloc, dealloc, realloc};
 
 use crate::{
     Error,
-    misc::{likely, string_into_raw_parts},
+    misc::likely,
     source::{NonVolatile, Source},
     value::{builder::*, misc::string_impl, owned},
 };
@@ -172,7 +172,11 @@ impl<'a> From<&'a str> for String<'a> {
 impl From<std::string::String> for String<'_> {
     #[inline]
     fn from(value: std::string::String) -> Self {
-        let (buf, len, cap) = string_into_raw_parts(value);
+        let mut value = ManuallyDrop::new(value);
+        let buf = value.as_mut_ptr();
+        let len = value.len();
+        let cap = value.capacity();
+
         Self(Inner::Heap { buf, len, cap })
     }
 }

--- a/src/value/borrowed/string.rs
+++ b/src/value/borrowed/string.rs
@@ -6,7 +6,7 @@ use std::alloc::{alloc, dealloc, realloc};
 
 use crate::{
     Error,
-    misc::likely,
+    misc::{likely, string_into_raw_parts},
     source::{NonVolatile, Source},
     value::{builder::*, misc::string_impl, owned},
 };
@@ -172,7 +172,7 @@ impl<'a> From<&'a str> for String<'a> {
 impl From<std::string::String> for String<'_> {
     #[inline]
     fn from(value: std::string::String) -> Self {
-        let (buf, len, cap) = value.into_raw_parts();
+        let (buf, len, cap) = string_into_raw_parts(value);
         Self(Inner::Heap { buf, len, cap })
     }
 }

--- a/src/value/owned/string.rs
+++ b/src/value/owned/string.rs
@@ -1,9 +1,12 @@
-use core::{alloc::Layout, hint::unreachable_unchecked, ptr::dangling_mut, slice::from_raw_parts};
+use core::{
+    alloc::Layout, hint::unreachable_unchecked, mem::ManuallyDrop, ptr::dangling_mut,
+    slice::from_raw_parts,
+};
 use std::alloc::{alloc, dealloc, realloc};
 
 use crate::{
     Error,
-    misc::{likely, string_into_raw_parts},
+    misc::likely,
     source::Source,
     value::{builder::*, misc::string_impl},
 };
@@ -178,7 +181,11 @@ impl From<&str> for String {
 impl From<std::string::String> for String {
     #[inline]
     fn from(value: std::string::String) -> Self {
-        let (buf, len, cap) = string_into_raw_parts(value);
+        let mut value = ManuallyDrop::new(value);
+        let buf = value.as_mut_ptr();
+        let len = value.len();
+        let cap = value.capacity();
+
         Self(Inner::Heap { buf, len, cap })
     }
 }

--- a/src/value/owned/string.rs
+++ b/src/value/owned/string.rs
@@ -3,7 +3,7 @@ use std::alloc::{alloc, dealloc, realloc};
 
 use crate::{
     Error,
-    misc::likely,
+    misc::{likely, string_into_raw_parts},
     source::Source,
     value::{builder::*, misc::string_impl},
 };
@@ -178,7 +178,7 @@ impl From<&str> for String {
 impl From<std::string::String> for String {
     #[inline]
     fn from(value: std::string::String) -> Self {
-        let (buf, len, cap) = value.into_raw_parts();
+        let (buf, len, cap) = string_into_raw_parts(value);
         Self(Inner::Heap { buf, len, cap })
     }
 }

--- a/src/value/owned/string.rs
+++ b/src/value/owned/string.rs
@@ -182,11 +182,12 @@ impl From<std::string::String> for String {
     #[inline]
     fn from(value: std::string::String) -> Self {
         let mut value = ManuallyDrop::new(value);
-        let buf = value.as_mut_ptr();
-        let len = value.len();
-        let cap = value.capacity();
 
-        Self(Inner::Heap { buf, len, cap })
+        Self(Inner::Heap {
+            buf: value.as_mut_ptr(),
+            len: value.len(),
+            cap: value.capacity(),
+        })
     }
 }
 


### PR DESCRIPTION
Fix builds on stable Rust versions before 1.93 by replacing direct `String::into_raw_parts` calls with a stable `ManuallyDrop`-based helper.

The crate uses `edition = "2024"`, which requires a compiler that supports Rust 2024. However, `String::into_raw_parts` is only stable starting in Rust 1.93. Using it directly makes the crate fail to compile on stable Rust 1.92 with `E0658: use of unstable library feature vec_into_raw_parts`.

This change avoids implicitly requiring Rust 1.93 just for this API while preserving the same zero-copy ownership transfer behavior.